### PR TITLE
Replaced ISO-8859-1 encoded copyright character (\xA9) with "(c)". fixes #129

### DIFF
--- a/third-party/uxf/src/lib/backplane/_unit-tests/ut-dom3ls.js
+++ b/third-party/uxf/src/lib/backplane/_unit-tests/ut-dom3ls.js
@@ -3,7 +3,7 @@
 //
 // The Ubiquity XForms module adds XForms support to the Ubiquity library.
 //
-// Copyright © 2008-9 Backplane Ltd.
+// Copyright (c) 2008-9 Backplane Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/third-party/uxf/src/lib/backplane/_unit-tests/ut-file.js
+++ b/third-party/uxf/src/lib/backplane/_unit-tests/ut-file.js
@@ -4,7 +4,7 @@
 // The Ubiquity Backplane module provides a backplane layer for other modules
 // in the Ubiquity library.
 //
-// Copyright © 2008-9 Backplane Ltd.
+// Copyright (c) 2008-9 Backplane Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/third-party/uxf/src/lib/backplane/_unit-tests/ut-fileio.js
+++ b/third-party/uxf/src/lib/backplane/_unit-tests/ut-fileio.js
@@ -3,7 +3,7 @@
 //
 // The Ubiquity XForms module adds XForms support to the Ubiquity library.
 //
-// Copyright © 2008-9 Backplane Ltd.
+// Copyright (c) 2008-9 Backplane Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/third-party/uxf/src/lib/backplane/_unit-tests/ut-scheme-handler.js
+++ b/third-party/uxf/src/lib/backplane/_unit-tests/ut-scheme-handler.js
@@ -3,7 +3,7 @@
 //
 // The Ubiquity XForms module adds XForms support to the Ubiquity library.
 //
-// Copyright © 2008-9 Backplane Ltd.
+// Copyright (c) 2008-9 Backplane Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/third-party/uxf/src/lib/backplane/dom/dom3ls.js
+++ b/third-party/uxf/src/lib/backplane/dom/dom3ls.js
@@ -3,7 +3,7 @@
 //
 // The Ubiquity XForms module adds XForms support to the Ubiquity library.
 //
-// Copyright © 2008-9 Backplane Ltd.
+// Copyright (c) 2008-9 Backplane Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/third-party/uxf/src/lib/backplane/io/file.js
+++ b/third-party/uxf/src/lib/backplane/io/file.js
@@ -3,7 +3,7 @@
 //
 // The Ubiquity XForms module adds XForms support to the Ubiquity library.
 //
-// Copyright © 2008-9 Backplane Ltd.
+// Copyright (c) 2008-9 Backplane Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/third-party/uxf/src/lib/functions/xforms/hmac.js
+++ b/third-party/uxf/src/lib/functions/xforms/hmac.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2009 Backplane Ltd.
+ * Copyright (c) 2009 Backplane Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/third-party/uxf/src/lib/functions/xslt20/format-number.js
+++ b/third-party/uxf/src/lib/functions/xslt20/format-number.js
@@ -1,5 +1,5 @@
 //
-// Copyright © 2009 Backplane Ltd.
+// Copyright (c) 2009 Backplane Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replaced ISO-8859-1 encoded copyright character (\xA9) with "(c)". fixes issue #129
