### PR TITLE
Moved inline styles for <xf:input>, <xf:textarea>, <xf:select>, and <xf:select1> out of javascript and into default.css. fixes #131

### DIFF
--- a/third-party/uxf/src/assets/style/default.css
+++ b/third-party/uxf/src/assets/style/default.css
@@ -157,6 +157,34 @@ xf|textarea pe-value textarea {
     background-color: white;
 }
 
+xforms\:textarea pe-value textarea,
+xf\:textarea pe-value textarea,
+xforms\:input pe-value input,
+xf\:input pe-value input {
+	padding: 0;
+	margin: 0;
+}
+
+xforms|textarea pe-value textarea,
+xf|textarea pe-value textarea,
+xforms|input pe-value input,
+xf|input pe-value input {
+	padding: 0;
+	margin: 0;
+}
+
+xforms\:input pe-value input,
+xf\:input pe-value input {
+    border: 0;
+    background-color: transparent;
+}
+
+xforms|input pe-value input,
+xf|input pe-value input {
+    border: 0;
+    background-color: transparent;
+}
+
 xforms\:input xforms\:label pe-value,
 xf\:input xf\:label pe-value,
 xforms\:secret xforms\:label pe-value,
@@ -600,6 +628,25 @@ xf|select.appearance-minimal xf|label pe-value, xforms|select.appearance-minimal
     display:inline-block;
 }
 
+xf\:select pe-value input,
+xf\:select1 pe-value input,
+xforms\:select pe-value input,
+xforms\:select1 pe-value input {
+	background-color: transparent;
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
+xf|select pe-value input,
+xf|select1 pe-value input,
+xforms|select pe-value input,
+xforms|select1 pe-value input {
+	background-color: transparent;
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
 
 .ux-drop-button {
     font-size:1pt;

--- a/third-party/uxf/src/lib/xforms/commonselect.js
+++ b/third-party/uxf/src/lib/xforms/commonselect.js
@@ -67,7 +67,6 @@ var XFormsCommonSelectValue = new UX.Class({
 		if (this.element.ownerDocument.media == "print") return;
 		
 		var input = document.createElement('input');
-		input.style.cssText = "backgroundColor:transparent; padding: 0; margin: 0; border: 0";
 		var select = DECORATOR.getBehaviour(this.element.parentNode);
 		var self = this;
 

--- a/third-party/uxf/src/lib/xforms/input-value-boolean.js
+++ b/third-party/uxf/src/lib/xforms/input-value-boolean.js
@@ -32,9 +32,6 @@ var XFormsBooleanValue = new UX.Class({
 		var eventName = "click";
 		input.type = "checkbox";
 
-		UX.addStyle(input, "backgroundColor", "transparent");
-		UX.addStyle(input, "padding", "0");
-		UX.addStyle(input, "margin", "0");
 		UX.addClassName(input, "ux-input-checkbox");
 		UX.addClassName(this.element, "ux-boolean-value");
 

--- a/third-party/uxf/src/lib/xforms/input-value.js
+++ b/third-party/uxf/src/lib/xforms/input-value.js
@@ -39,13 +39,6 @@ var XFormsInputValue = new UX.Class({
 		var input = document.createElement(elementType);
 		var eventName = (this.element.parentNode.getAttribute("incremental") === "true") ? "keyup" : "change";
 
-		UX.addStyle(input, "backgroundColor", "transparent");
-		UX.addStyle(input, "padding", "0");
-		UX.addStyle(input, "margin", "0");
-		if (name !== "textarea") {
-			UX.addStyle(input, "border", "0");
-		}
-
 		var self = this;
 		if (input.addEventListener) {
 			input.addEventListener(eventName, function(event) {


### PR DESCRIPTION
Moved inline styles for `<xf:input>`, `<xf:textarea>`, `<xf:select>`, and `<xf:select1>` out of javascript and into default.css. fixes #131
